### PR TITLE
Add reset_db command to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ If you get a "virtual memory error" with any of the postgres commands, close PyC
 - Set the project interpreter to ~/virtualenvs/yunity-core/bin/python
 - Run yunity-core (Shift+F10)
 
-If a migration fails with a error message, similar to `django.db.utils.ProgrammingError: column "id" referenced in foreign key constraint does not exist`, run the command `./manage.py reset_db`, followed by `./manage.py reset_db` to reset the database.
+If a migration fails with a error message, similar to `django.db.utils.ProgrammingError: column "id" referenced in foreign key constraint does not exist`, run the command `./manage.py reset_db`, followed by `./manage.py migrate` to reset the database.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ If you get a "virtual memory error" with any of the postgres commands, close PyC
 - Set the project interpreter to ~/virtualenvs/yunity-core/bin/python
 - Run yunity-core (Shift+F10)
 
+If a migration fails with a error message, similar to `django.db.utils.ProgrammingError: column "id" referenced in foreign key constraint does not exist`, run the command `./manage.py reset_db`, followed by `./manage.py reset_db` to reset the database.
+
 ## Architecture
 
 ### Data model


### PR DESCRIPTION
Sometimes the Django migrations fail, in which case it is helpful to reset the database and run the migrations again.