### PR TITLE
Stores simplification

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -18,7 +18,7 @@ from django.contrib import admin
 
 from rest_framework_nested import routers
 from yunity.api.public.auth import AuthViewSet
-from yunity.api.public.chats import ChatViewSet, ChatMessageViewSet, UserChatViewSet
+from yunity.api.public.chats import ChatViewSet, ChatMessageViewSet
 from yunity.api.public.groups import GroupViewSet
 from yunity.api.public.users import UserViewSet
 from yunity.stores.api import StoreList, StoreSummary, PickupDatesViewSet
@@ -35,7 +35,6 @@ router.register(r'users', UserViewSet)
 router.register(r'conversations', ChatViewSet)
 chat_router = routers.NestedSimpleRouter(router, r'conversations', lookup='conversations')
 chat_router.register(r'messages', ChatMessageViewSet, base_name='conversations-messages')
-router.register(r'conversations-by-user', UserChatViewSet)
 
 # pickup date endpoints
 router.register(r'pickup-dates', PickupDatesViewSet)

--- a/config/urls.py
+++ b/config/urls.py
@@ -21,7 +21,7 @@ from yunity.api.public.auth import AuthViewSet
 from yunity.api.public.chats import ChatViewSet, ChatMessageViewSet
 from yunity.api.public.groups import GroupViewSet
 from yunity.api.public.users import UserViewSet
-from yunity.stores.api import StoreList, StoreSummary, PickupDatesViewSet
+from yunity.stores.api import StoreViewSet, PickupDatesViewSet
 
 router = routers.DefaultRouter()
 
@@ -39,11 +39,12 @@ chat_router.register(r'messages', ChatMessageViewSet, base_name='conversations-m
 # pickup date endpoints
 router.register(r'pickup-dates', PickupDatesViewSet)
 
+# Store endpoints
+router.register(r'stores', StoreViewSet)
+
 urlpatterns = [
     url(r'^api/', include(router.urls, namespace='api')),
     url(r'^api/', include(chat_router.urls, namespace='api')),
-    url(r'^api/stores/$', StoreList.as_view(), name='store-list'),
-    url(r'^api/stores/(?P<pk>[0-9]+)', StoreSummary.as_view(), name='store-summary'),
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^docs/', include('rest_framework_swagger.urls')),

--- a/yunity/api/public/chats.py
+++ b/yunity/api/public/chats.py
@@ -1,11 +1,7 @@
 from django.db.models import Max
-from rest_framework import status
-from rest_framework.decorators import detail_route
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.response import Response
-from yunity.conversations.services import get_or_create_user_conversation, add_to_conversation
-from yunity.conversations.serializers import ConversationSerializer, MessageSerializer, ConversationByUserSerializer
-from yunity.conversations.models import Conversation as ConversationModel, ConversationType
+from yunity.conversations.serializers import ConversationSerializer, MessageSerializer
+from yunity.conversations.models import Conversation as ConversationModel
 from yunity.conversations.models import ConversationMessage as MessageModel
 from rest_framework import viewsets, mixins
 
@@ -41,22 +37,3 @@ class ChatMessageViewSet(mixins.CreateModelMixin,
         "chat_pk isn't available in the serializer, so insert it here"
         request.data['in_conversation_id'] = kwargs.pop('conversations_pk')
         return super().create(request, *args, **kwargs)
-
-
-class UserChatViewSet(mixins.RetrieveModelMixin,
-                      viewsets.GenericViewSet):
-    serializer_class = ConversationByUserSerializer
-    queryset = ConversationModel.objects
-    lookup_field = 'participants__id'
-
-    def get_queryset(self):
-        return self.queryset.filter(type=ConversationType.ONE_ON_ONE).filter(participants__id=self.request.user.id)
-
-    @detail_route(methods=['post'], url_path='messages')
-    def post_message(self, request, participants__id):
-        participants = [request.user.id, participants__id]
-        serializer = self.get_serializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        conversation = get_or_create_user_conversation(participants)
-        add_to_conversation(conversation.id, request.user.id, serializer.validated_data)
-        return Response(self.get_serializer(conversation).data, status=status.HTTP_201_CREATED)

--- a/yunity/stores/api.py
+++ b/yunity/stores/api.py
@@ -1,18 +1,18 @@
-from rest_framework import mixins, viewsets, generics, status
+from rest_framework import mixins, viewsets, status
 from rest_framework.decorators import detail_route
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from yunity.stores.serializers import StoreDetailSerializer, StoreSummarySerializer, PickupDateSerializer
+from yunity.stores.serializers import StoreSerializer, PickupDateSerializer
 from yunity.stores.models import Store as StoreModel, PickupDate as PickupDateModel
 
 
-class StoreList(generics.ListCreateAPIView):
-    serializer_class = StoreDetailSerializer
-    queryset = StoreModel.objects
-
-
-class StoreSummary(generics.RetrieveUpdateDestroyAPIView):
-    serializer_class = StoreSummarySerializer
+class StoreViewSet(mixins.CreateModelMixin,
+                   mixins.ListModelMixin,
+                   mixins.RetrieveModelMixin,
+                   mixins.UpdateModelMixin,
+                   mixins.DestroyModelMixin,
+                   viewsets.GenericViewSet):
+    serializer_class = StoreSerializer
     queryset = StoreModel.objects
 
 

--- a/yunity/stores/serializers.py
+++ b/yunity/stores/serializers.py
@@ -1,17 +1,6 @@
 from rest_framework import serializers
-from yunity.groups.models import Group
 from yunity.stores.models import Store as StoreModel
 from yunity.stores.models import PickupDate as PickupDateModel
-
-
-class StoreDetailSerializer(serializers.Serializer):
-    id = serializers.IntegerField(read_only=True)
-    name = serializers.CharField()
-    description = serializers.CharField()
-    group = serializers.PrimaryKeyRelatedField(queryset=Group.objects.all())
-
-    def create(self, validated_data):
-        return StoreModel.objects.create(**validated_data)
 
 
 class PickupDateSerializer(serializers.Serializer):
@@ -21,8 +10,7 @@ class PickupDateSerializer(serializers.Serializer):
                                                        many=True,
                                                        read_only=True)
     max_collectors = serializers.IntegerField()
-    store = serializers.PrimaryKeyRelatedField(  # source='stores.store',
-        queryset=StoreModel.objects.all())
+    store = serializers.PrimaryKeyRelatedField(queryset=StoreModel.objects.all())
 
     def create(self, validated_data):
         return PickupDateModel.objects.create(**validated_data)
@@ -34,5 +22,9 @@ class PickupDateSerializer(serializers.Serializer):
         return pickupdate
 
 
-class StoreSummarySerializer(StoreDetailSerializer):
+class StoreSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = StoreModel
+        fields = ['id', 'name', 'description', 'group', 'pickups']
+
     pickups = PickupDateSerializer(source='pickupdates', read_only=True, many=True)

--- a/yunity/stores/tests/test_serializer.py
+++ b/yunity/stores/tests/test_serializer.py
@@ -1,24 +1,24 @@
 from django.test import TestCase
 from yunity.groups.factories import Group
 from yunity.stores.factories import Store, PickupDate
-from yunity.stores.serializers import StoreSummarySerializer
+from yunity.stores.serializers import StoreSerializer
 from django.utils import timezone
 
 
-class TestStoreSummarySerializer(TestCase):
+class TestStoreSerializer(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestStoreSummarySerializer, cls).setUpClass()
+        super().setUpClass()
         cls.group = Group()
         cls.store = Store()
 
     def test_store_instantiation(self):
-        serializer = StoreSummarySerializer(self.store)
+        serializer = StoreSerializer(self.store)
         self.assertEqual(serializer.data['name'], self.store.name)
         self.assertEqual(len(serializer.data['pickups']), 0)
 
     def test_storesummary_pickups(self):
         PickupDate(store=self.store, date=timezone.now())
-        serializer = StoreSummarySerializer(self.store)
+        serializer = StoreSerializer(self.store)
         self.assertEqual(len(serializer.data['pickups']), 1)


### PR DESCRIPTION
The Stores API now also uses the DRF router.
Merged the serializer, now the pickups are returned also in the "list" serializer (but are about to be removed soon altogether).