### PR TITLE
Store API: Remove pickups field

### DIFF
--- a/yunity/stores/serializers.py
+++ b/yunity/stores/serializers.py
@@ -25,6 +25,4 @@ class PickupDateSerializer(serializers.Serializer):
 class StoreSerializer(serializers.ModelSerializer):
     class Meta:
         model = StoreModel
-        fields = ['id', 'name', 'description', 'group', 'pickups']
-
-    pickups = PickupDateSerializer(source='pickupdates', read_only=True, many=True)
+        fields = ['id', 'name', 'description', 'group']

--- a/yunity/stores/tests/test_serializer.py
+++ b/yunity/stores/tests/test_serializer.py
@@ -1,8 +1,7 @@
 from django.test import TestCase
 from yunity.groups.factories import Group
-from yunity.stores.factories import Store, PickupDate
+from yunity.stores.factories import Store
 from yunity.stores.serializers import StoreSerializer
-from django.utils import timezone
 
 
 class TestStoreSerializer(TestCase):
@@ -16,9 +15,3 @@ class TestStoreSerializer(TestCase):
     def test_store_instantiation(self):
         serializer = StoreSerializer(self.store)
         self.assertEqual(serializer.data['name'], self.store.name)
-        self.assertEqual(len(serializer.data['pickups']), 0)
-
-    def test_storesummary_pickups(self):
-        PickupDate(store=self.store, date=timezone.now())
-        serializer = StoreSerializer(self.store)
-        self.assertEqual(len(serializer.data['pickups']), 1)


### PR DESCRIPTION
The pickups can also be accessed through the pickup-dates endpoint, filtering by store ID.
Reduces complexity in the backend. See discussion in #156 .