### PR TITLE
Search in users, stores and groups

### DIFF
--- a/yunity/groups/api.py
+++ b/yunity/groups/api.py
@@ -1,3 +1,4 @@
+from rest_framework import filters
 from rest_framework import status, viewsets
 from rest_framework.decorators import detail_route
 from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly
@@ -10,6 +11,8 @@ class GroupViewSet(viewsets.ModelViewSet):
     queryset = GroupModel.objects.all()
     serializer_class = GroupSerializer
     filter_fields = ('members',)
+    filter_backends = (filters.SearchFilter,)
+    search_fields = ('name', 'description')
     permission_classes = (IsAuthenticatedOrReadOnly,)
 
     @detail_route(methods=['POST', 'GET'],

--- a/yunity/stores/api.py
+++ b/yunity/stores/api.py
@@ -1,3 +1,4 @@
+from rest_framework import filters
 from rest_framework import mixins, viewsets, status
 from rest_framework.decorators import detail_route
 from rest_framework.permissions import IsAuthenticated
@@ -15,6 +16,8 @@ class StoreViewSet(mixins.CreateModelMixin,
     serializer_class = StoreSerializer
     queryset = StoreModel.objects
     filter_fields = ('group',)
+    filter_backends = (filters.SearchFilter,)
+    search_fields = ('name', 'description')
 
 
 class PickupDatesViewSet(mixins.CreateModelMixin,

--- a/yunity/users/api.py
+++ b/yunity/users/api.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import get_user_model
+from rest_framework import filters
 from rest_framework import viewsets
 from yunity.users.serializers import UserSerializer
 
@@ -6,3 +7,5 @@ from yunity.users.serializers import UserSerializer
 class UserViewSet(viewsets.ModelViewSet):
     queryset = get_user_model().objects.all()
     serializer_class = UserSerializer
+    filter_backends = (filters.SearchFilter,)
+    search_fields = ('display_name', 'first_name', 'last_name')


### PR DESCRIPTION
Per-endpoint search:
`/api/users/?search=<text>`
`/api/stores/?search=<text>`
`/api/groups/?search=<text>`

It's _very_ easy to implement. The name of the search query could be changed, but I like its expressiveness.
Closes #169 